### PR TITLE
Add delegate for callbacks

### DIFF
--- a/AlertOnboarding/AlertChildPageViewController.xib
+++ b/AlertOnboarding/AlertChildPageViewController.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10116" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>

--- a/AlertOnboarding/AlertOnboarding.swift
+++ b/AlertOnboarding/AlertOnboarding.swift
@@ -9,7 +9,13 @@
 
 import UIKit
 
-public class AlertOnboarding: UIView {
+public protocol AlertOnboardingDelegate {
+    func alertOnboardingSkipped(lastStep: Int)
+    func alertOnboardingCompleted()
+    func alertOnboardingNext(nextStep: Int)
+}
+
+public class AlertOnboarding: UIView, AlertPageViewDelegate {
     
     //FOR DATA  ------------------------
     private var arrayOfImage = [String]()
@@ -42,6 +48,8 @@ public class AlertOnboarding: UIView {
     
     public var titleSkipButton = "SKIP"
     public var titleGotItButton = "GOT IT !"
+
+    public var delegate: AlertOnboardingDelegate?
     
     
     public init (arrayOfImage: [String], arrayOfTitle: [String], arrayOfDescription: [String]) {
@@ -79,6 +87,7 @@ public class AlertOnboarding: UIView {
         self.buttonBottom.setTitle(self.titleSkipButton, forState: .Normal)
         
         self.container = AlertPageViewController(arrayOfImage: arrayOfImage, arrayOfTitle: arrayOfTitle, arrayOfDescription: arrayOfDescription, alertView: self)
+        self.container.delegate = self
         self.insertSubview(self.container.view, aboveSubview: self)
         self.insertSubview(self.buttonBottom, aboveSubview: self)
         
@@ -99,6 +108,14 @@ public class AlertOnboarding: UIView {
     
     //Start the animation
     public func hide(){
+        // Check if onboarding was skipped
+        let currentStep = self.container.currentStep
+        if currentStep < (self.container.arrayOfImage.count - 1) {
+            self.delegate?.alertOnboardingSkipped(currentStep)
+        }
+        else {
+            self.delegate?.alertOnboardingCompleted()
+        }
         dispatch_async(dispatch_get_main_queue()) {
             () -> Void in
             self.animateForEnding()
@@ -201,6 +218,12 @@ public class AlertOnboarding: UIView {
     
     func onClick(){
         self.hide()
+    }
+
+    //MARK: ALERTPAGEVIEWDELEGATE    --------------------------------------
+
+    func nextStep(step: Int) {
+        self.delegate?.alertOnboardingNext(step)
     }
     
     //MARK: OTHERS    --------------------------------------

--- a/AlertOnboarding/AlertPageViewController.swift
+++ b/AlertOnboarding/AlertPageViewController.swift
@@ -8,6 +8,10 @@
 
 import UIKit
 
+protocol AlertPageViewDelegate {
+    func nextStep(step: Int)
+}
+
 class AlertPageViewController: UIViewController, UIPageViewControllerDataSource, UIPageViewControllerDelegate {
     
     //FOR DESIGN
@@ -20,7 +24,10 @@ class AlertPageViewController: UIViewController, UIPageViewControllerDataSource,
     var arrayOfTitle: [String]!
     var arrayOfDescription: [String]!
     var viewControllers = [UIViewController]()
-    
+
+    var currentStep = 0
+    var delegate: AlertPageViewDelegate?
+
     
     init (arrayOfImage: [String], arrayOfTitle: [String], arrayOfDescription: [String], alertView: AlertOnboarding) {
         super.init(nibName: nil, bundle: nil)
@@ -120,6 +127,8 @@ class AlertPageViewController: UIViewController, UIPageViewControllerDataSource,
     func pageViewController(pageViewController: UIPageViewController, didFinishAnimating finished: Bool, previousViewControllers: [UIViewController], transitionCompleted completed: Bool) {
         let pageContentViewController = pageViewController.viewControllers![0] as! AlertChildPageViewController
         let index = pageContentViewController.pageIndex
+        self.currentStep = (arrayOfImage.count - index - 1)
+        self.delegate?.nextStep(self.currentStep)
         if pageControl != nil {
             pageControl.currentPage = arrayOfImage.count - index - 1
             if pageControl.currentPage == arrayOfImage.count - 1 {
@@ -129,7 +138,7 @@ class AlertPageViewController: UIViewController, UIPageViewControllerDataSource,
             }
         }
     }
-    
+
     
     func presentationCountForPageViewController(pageViewController: UIPageViewController) -> Int {
         return arrayOfImage.count

--- a/AlertOnboarding/Base.lproj/LaunchScreen.storyboard
+++ b/AlertOnboarding/Base.lproj/LaunchScreen.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9532" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" initialViewController="01J-lp-oVM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" initialViewController="01J-lp-oVM">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <scenes>
         <!--View Controller-->

--- a/AlertOnboarding/Base.lproj/Main.storyboard
+++ b/AlertOnboarding/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
@@ -17,8 +17,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZlQ-XS-jTS">
-                                <rect key="frame" x="277" y="285" width="46" height="30"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZlQ-XS-jTS">
+                                <rect key="frame" x="200" y="200" width="200" height="200"/>
                                 <color key="backgroundColor" red="0.6705882353" green="0.69411764710000001" blue="0.76862745099999996" alpha="1" colorSpace="calibratedRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="200" id="Cth-v2-DvV"/>

--- a/Pod/Classes/AlertOnboarding.swift
+++ b/Pod/Classes/AlertOnboarding.swift
@@ -9,7 +9,13 @@
 
 import UIKit
 
-public class AlertOnboarding: UIView {
+public protocol AlertOnboardingDelegate {
+    func alertOnboardingSkipped(lastStep: Int)
+    func alertOnboardingCompleted()
+    func alertOnboardingNext(nextStep: Int)
+}
+
+public class AlertOnboarding: UIView, AlertPageViewDelegate {
     
     //FOR DATA  ------------------------
     private var arrayOfImage = [String]()
@@ -42,6 +48,8 @@ public class AlertOnboarding: UIView {
     
     public var titleSkipButton = "SKIP"
     public var titleGotItButton = "GOT IT !"
+
+    public var delegate: AlertOnboardingDelegate?
     
     
     public init (arrayOfImage: [String], arrayOfTitle: [String], arrayOfDescription: [String]) {
@@ -79,6 +87,7 @@ public class AlertOnboarding: UIView {
         self.buttonBottom.setTitle(self.titleSkipButton, forState: .Normal)
         
         self.container = AlertPageViewController(arrayOfImage: arrayOfImage, arrayOfTitle: arrayOfTitle, arrayOfDescription: arrayOfDescription, alertView: self)
+        self.container.delegate = self
         self.insertSubview(self.container.view, aboveSubview: self)
         self.insertSubview(self.buttonBottom, aboveSubview: self)
         
@@ -99,6 +108,14 @@ public class AlertOnboarding: UIView {
     
     //Start the animation
     public func hide(){
+        // Check if onboarding was skipped
+        let currentStep = self.container.currentStep
+        if currentStep < (self.container.arrayOfImage.count - 1) {
+            self.delegate?.alertOnboardingSkipped(currentStep)
+        }
+        else {
+            self.delegate?.alertOnboardingCompleted()
+        }
         dispatch_async(dispatch_get_main_queue()) {
             () -> Void in
             self.animateForEnding()
@@ -201,6 +218,12 @@ public class AlertOnboarding: UIView {
     
     func onClick(){
         self.hide()
+    }
+
+    //MARK: ALERTPAGEVIEWDELEGATE    --------------------------------------
+
+    func nextStep(step: Int) {
+        self.delegate?.alertOnboardingNext(step)
     }
     
     //MARK: OTHERS    --------------------------------------

--- a/Pod/Classes/AlertPageViewController.swift
+++ b/Pod/Classes/AlertPageViewController.swift
@@ -8,6 +8,10 @@
 
 import UIKit
 
+protocol AlertPageViewDelegate {
+    func nextStep(step: Int)
+}
+
 class AlertPageViewController: UIViewController, UIPageViewControllerDataSource, UIPageViewControllerDelegate {
     
     //FOR DESIGN
@@ -20,7 +24,10 @@ class AlertPageViewController: UIViewController, UIPageViewControllerDataSource,
     var arrayOfTitle: [String]!
     var arrayOfDescription: [String]!
     var viewControllers = [UIViewController]()
-    
+
+    var currentStep = 0
+    var delegate: AlertPageViewDelegate?
+
     
     init (arrayOfImage: [String], arrayOfTitle: [String], arrayOfDescription: [String], alertView: AlertOnboarding) {
         super.init(nibName: nil, bundle: nil)
@@ -120,6 +127,8 @@ class AlertPageViewController: UIViewController, UIPageViewControllerDataSource,
     func pageViewController(pageViewController: UIPageViewController, didFinishAnimating finished: Bool, previousViewControllers: [UIViewController], transitionCompleted completed: Bool) {
         let pageContentViewController = pageViewController.viewControllers![0] as! AlertChildPageViewController
         let index = pageContentViewController.pageIndex
+        self.currentStep = (arrayOfImage.count - index - 1)
+        self.delegate?.nextStep(self.currentStep)
         if pageControl != nil {
             pageControl.currentPage = arrayOfImage.count - index - 1
             if pageControl.currentPage == arrayOfImage.count - 1 {
@@ -129,7 +138,7 @@ class AlertPageViewController: UIViewController, UIPageViewControllerDataSource,
             }
         }
     }
-    
+
     
     func presentationCountForPageViewController(pageViewController: UIPageViewController) -> Int {
         return arrayOfImage.count
@@ -160,7 +169,7 @@ class AlertPageViewController: UIViewController, UIPageViewControllerDataSource,
             let pageControl = UIPageControl.appearanceWhenContainedInInstancesOfClasses([AlertPageViewController.self])
             pageControl.pageIndicatorTintColor = UIColor.clearColor()
             pageControl.currentPageIndicatorTintColor = UIColor.clearColor()
-            
+
         } else {
             // Fallback on earlier versions
         }

--- a/README.md
+++ b/README.md
@@ -72,6 +72,30 @@ self.alertView.titleSkipButton = "PASS"
 self.alertView.titleGotItButton = "UNDERSTOOD !"
 
 ```
+**AlertOnboardingDelegate**
+
+If you want to know when the user completes onboarding, skips onboarding, or triggers the next step, you can use the `AlertOnboardingDelegate` to listen for these updates.
+
+```swift
+
+//... when initialising AlertOnboarding
+alertView.delegate = self
+
+//... inside your class that conforms to AlertOnboardingDelegate
+
+func alertOnboardingSkipped(lastStep: Int) {
+   print("Onboarding skipped! Last step: \(lastStep)")
+}
+
+func alertOnboardingCompleted() {
+   print("Onboarding completed!")
+}
+
+func alertOnboardingNext(nextStep: Int) {
+   print("Next step triggered! \(nextStep)")
+}
+
+```
 
 ## FEATURES
 - [x] Multi-Device Full Support


### PR DESCRIPTION
I've added a delegate that provides callbacks that are fired when onboarding has been completed, skipped, or when the next step has been triggered.

This can be useful for analytics, or for integrating the onboarding with a request for location permissions (for example).
