### PR TITLE
Add background fade to the opening and dismissing animation

### DIFF
--- a/AlertOnboarding.xcodeproj/project.pbxproj
+++ b/AlertOnboarding.xcodeproj/project.pbxproj
@@ -116,6 +116,7 @@
 				TargetAttributes = {
 					37845A641D994CBA009B3734 = {
 						CreatedOnToolsVersion = 8.0;
+						LastSwiftMigration = 1240;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -125,6 +126,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -291,7 +293,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.cookminute.AlertOnboarding;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -304,7 +306,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.cookminute.AlertOnboarding;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/AlertOnboarding/AlertChildPageViewController.swift
+++ b/AlertOnboarding/AlertChildPageViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 
 class AlertChildPageViewController: UIViewController {
     
-    var pageIndex: Int!
+    var pageIndex: Int = 0
     
     @IBOutlet weak var image: UIImageView!
     @IBOutlet weak var labelMainTitle: UILabel!

--- a/AlertOnboarding/AlertChildPageViewController.swift
+++ b/AlertOnboarding/AlertChildPageViewController.swift
@@ -9,17 +9,17 @@
 import UIKit
 
 class AlertChildPageViewController: UIViewController {
-    
+
     var pageIndex: Int = 0
-    
+
     @IBOutlet weak var image: UIImageView!
     @IBOutlet weak var labelMainTitle: UILabel!
     @IBOutlet weak var labelDescription: UILabel!
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
     }
-    
+
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
     }

--- a/AlertOnboarding/AlertOnboarding.swift
+++ b/AlertOnboarding/AlertOnboarding.swift
@@ -202,6 +202,7 @@ open class AlertOnboarding: UIView, AlertPageViewDelegate {
     fileprivate func animateForEnding(){
         UIView.animate(withDuration: 0.2, delay: 0.0, options: UIViewAnimationOptions.curveEaseOut, animations: {
             self.alpha = 0.0
+            self.background.alpha = 0.0
             }, completion: {
                 (finished: Bool) -> Void in
                 // On main thread

--- a/AlertOnboarding/AlertOnboarding.swift
+++ b/AlertOnboarding/AlertOnboarding.swift
@@ -84,7 +84,7 @@ open class AlertOnboarding: UIView, AlertPageViewDelegate {
         self.buttonBottom.backgroundColor = colorButtonBottomBackground
         self.backgroundColor = colorForAlertViewBackground
         self.buttonBottom.setTitleColor(colorButtonText, for: UIControl.State())
-        self.buttonBottom.setTitle(self.titleSkipButton, for: UIControl.State())
+        self.buttonBottom.setTitle(titleSkipButton, for: UIControl.State())
         
         self.container = AlertPageViewController(arrayOfImage: arrayOfImage, arrayOfTitle: arrayOfTitle, arrayOfDescription: arrayOfDescription, alertView: self)
         self.container.delegate = self
@@ -221,13 +221,13 @@ open class AlertOnboarding: UIView, AlertPageViewDelegate {
     //MARK: BUTTON ACTIONS
     
     @objc func onClick(){
-        self.hide()
+        hide()
     }
     
     //MARK: ALERTPAGEVIEWDELEGATE
     
     func nextStep(_ step: Int) {
-        self.delegate?.alertOnboardingNext(step)
+        delegate?.alertOnboardingNext(step)
     }
     
     //MARK: OTHERS
@@ -242,13 +242,13 @@ open class AlertOnboarding: UIView, AlertPageViewDelegate {
     //MARK: NOTIFICATIONS PROCESS
     fileprivate func interceptOrientationChange(){
         UIDevice.current.beginGeneratingDeviceOrientationNotifications()
-        NotificationCenter.default.addObserver(self, selector: #selector(AlertOnboarding.onOrientationChange), name: UIDevice.orientationDidChangeNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(onOrientationChange), name: UIDevice.orientationDidChangeNotification, object: nil)
     }
     
     @objc func onOrientationChange(){
-        if let superview = self.superview {
-            self.configureConstraints(superview)
-            self.container.configureConstraintsForPageControl()
+        if let superview = superview {
+            configureConstraints(superview)
+            container.configureConstraintsForPageControl()
         }
     }
 }

--- a/AlertOnboarding/AlertOnboarding.swift
+++ b/AlertOnboarding/AlertOnboarding.swift
@@ -22,9 +22,10 @@ open class AlertOnboarding: UIView, AlertPageViewDelegate {
     fileprivate var arrayOfDescription = [String]()
     
     //FOR DESIGN    ------------------------
-    open var buttonBottom: UIButton!
+    open var buttonBottom = UIButton()
+
     fileprivate var container: AlertPageViewController!
-    open var background: UIView!
+    open var background = UIView()
     
     
     //PUBLIC VARS   ------------------------
@@ -181,8 +182,8 @@ open class AlertOnboarding: UIView, AlertPageViewDelegate {
         
         
         //Constraints for background
-        let widthContraintsForBackground = NSLayoutConstraint(item: self.background, attribute:.width, relatedBy: .equal, toItem: superView, attribute: .width, multiplier: 1, constant: 0)
-        let heightConstraintForBackground = NSLayoutConstraint.init(item: self.background, attribute: .height, relatedBy: .equal, toItem: superView, attribute: .height, multiplier: 1, constant: 0)
+        let widthContraintsForBackground = NSLayoutConstraint(item: background, attribute:.width, relatedBy: .equal, toItem: superView, attribute: .width, multiplier: 1, constant: 0)
+        let heightConstraintForBackground = NSLayoutConstraint.init(item: background, attribute: .height, relatedBy: .equal, toItem: superView, attribute: .height, multiplier: 1, constant: 0)
         
         NSLayoutConstraint.activate([horizontalContraintsAlertView, verticalContraintsAlertView,heightConstraintForAlertView, widthConstraintForAlertView,
                                      verticalContraintsButtonBottom, heightConstraintForButtonBottom, widthConstraintForButtonBottom, pinContraintsButtonBottom,

--- a/AlertOnboarding/AlertOnboarding.swift
+++ b/AlertOnboarding/AlertOnboarding.swift
@@ -109,8 +109,8 @@ open class AlertOnboarding: UIView, AlertPageViewDelegate {
     //Hide onboarding with animation
     open func hide(){
         checkIfOnboardingWasSkipped()
-        DispatchQueue.main.async { () -> Void in
-            self.animateForEnding()
+        DispatchQueue.main.async { [weak self] in
+            self?.animateForEnding()
         }
     }
     

--- a/AlertOnboarding/AlertOnboarding.swift
+++ b/AlertOnboarding/AlertOnboarding.swift
@@ -192,35 +192,43 @@ open class AlertOnboarding: UIView, AlertPageViewDelegate {
     }
     
     //MARK: FOR ANIMATIONS
-    fileprivate func animateForOpening(){
+    fileprivate func animateForOpening() {
         self.alpha = 1.0
         self.transform = CGAffineTransform(scaleX: 0.3, y: 0.3)
-        UIView.animate(withDuration: 1, delay: 0.0, usingSpringWithDamping: 0.5, initialSpringVelocity: 0.5, options: [], animations: {
+        UIView.animate(withDuration: 1, delay: 0.0, usingSpringWithDamping: 0.5, initialSpringVelocity: 0.5, options: [], animations: { [weak self] in
+            guard let self = self else { return }
+
             self.background.alpha = 0.5
             self.transform = CGAffineTransform(scaleX: 1, y: 1)
             }, completion: nil)
     }
     
-    fileprivate func animateForEnding(){
-        UIView.animate(withDuration: 0.2, delay: 0.0, options: UIView.AnimationOptions.curveEaseOut, animations: {
+    fileprivate func animateForEnding() {
+        UIView.animate(withDuration: 0.2, delay: 0.0, options: UIView.AnimationOptions.curveEaseOut, animations: { [weak self] in
+            guard let self = self else { return }
+
             self.alpha = 0.0
             self.background.alpha = 0.0
-            }, completion: {
-                (finished: Bool) -> Void in
+            }, completion: { [weak self] finished in
                 // On main thread
-                DispatchQueue.main.async {
-                    () -> Void in
-                    self.background.removeFromSuperview()
-                    self.removeFromSuperview()
-                    self.container.removeFromParent()
-                    self.container.view.removeFromSuperview()
-                }
+                self?.endingAnimationCompleted()
         })
+    }
+
+    private func endingAnimationCompleted() {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+
+            self.background.removeFromSuperview()
+            self.removeFromSuperview()
+            self.container.removeFromParent()
+            self.container.view.removeFromSuperview()
+        }
     }
     
     //MARK: BUTTON ACTIONS
     
-    @objc func onClick(){
+    @objc func onClick() {
         hide()
     }
     

--- a/AlertOnboarding/AlertOnboarding.swift
+++ b/AlertOnboarding/AlertOnboarding.swift
@@ -81,34 +81,34 @@ open class AlertOnboarding: UIView, AlertPageViewDelegate {
     open func show() {
         
         //Update Color
-        self.buttonBottom.backgroundColor = colorButtonBottomBackground
-        self.backgroundColor = colorForAlertViewBackground
-        self.buttonBottom.setTitleColor(colorButtonText, for: UIControl.State())
-        self.buttonBottom.setTitle(titleSkipButton, for: UIControl.State())
+        buttonBottom.backgroundColor = colorButtonBottomBackground
+        backgroundColor = colorForAlertViewBackground
+        buttonBottom.setTitleColor(colorButtonText, for: UIControl.State())
+        buttonBottom.setTitle(titleSkipButton, for: UIControl.State())
         
-        self.container = AlertPageViewController(arrayOfImage: arrayOfImage, arrayOfTitle: arrayOfTitle, arrayOfDescription: arrayOfDescription, alertView: self)
-        self.container.delegate = self
-        self.insertSubview(self.container.view, aboveSubview: self)
-        self.insertSubview(self.buttonBottom, aboveSubview: self)
+        container = AlertPageViewController(arrayOfImage: arrayOfImage, arrayOfTitle: arrayOfTitle, arrayOfDescription: arrayOfDescription, alertView: self)
+        container.delegate = self
+        insertSubview(container.view, aboveSubview: self)
+        insertSubview(buttonBottom, aboveSubview: self)
         
         // Only show once
-        if self.superview != nil {
+        if superview != nil {
             return
         }
         
         // Find current stop viewcontroller
         if let topController = getTopViewController() {
             let superView: UIView = topController.view
-            superView.addSubview(self.background)
+            superView.addSubview(background)
             superView.addSubview(self)
-            self.configureConstraints(topController.view)
-            self.animateForOpening()
+            configureConstraints(topController.view)
+            animateForOpening()
         }
     }
     
     //Hide onboarding with animation
     open func hide(){
-        self.checkIfOnboardingWasSkipped()
+        checkIfOnboardingWasSkipped()
         DispatchQueue.main.async { () -> Void in
             self.animateForEnding()
         }
@@ -121,12 +121,12 @@ open class AlertOnboarding: UIView, AlertPageViewDelegate {
     
     //MARK: Check if onboarding was skipped
     fileprivate func checkIfOnboardingWasSkipped(){
-        let currentStep = self.container.currentStep
-        if currentStep < (self.container.arrayOfImage.count - 1) && !self.container.isCompleted{
-            self.delegate?.alertOnboardingSkipped(currentStep, maxStep: self.container.maxStep)
+        let currentStep = container.currentStep
+        if currentStep < (container.arrayOfImage.count - 1) && !container.isCompleted{
+            delegate?.alertOnboardingSkipped(currentStep, maxStep: container.maxStep)
         }
         else {
-            self.delegate?.alertOnboardingCompleted()
+            delegate?.alertOnboardingCompleted()
         }
     }
     
@@ -134,51 +134,51 @@ open class AlertOnboarding: UIView, AlertPageViewDelegate {
     //MARK: FOR CONFIGURATION
     fileprivate func configure(_ arrayOfImage: [String], arrayOfTitle: [String], arrayOfDescription: [String]) {
         
-        self.buttonBottom = UIButton(frame: CGRect(x: 0,y: 0, width: 0, height: 0))
-        self.buttonBottom.titleLabel?.font = UIFont(name: "Avenir-Black", size: 15)
-        self.buttonBottom.addTarget(self, action: #selector(AlertOnboarding.onClick), for: .touchUpInside)
+        buttonBottom = UIButton(frame: CGRect(x: 0,y: 0, width: 0, height: 0))
+        buttonBottom.titleLabel?.font = UIFont(name: "Avenir-Black", size: 15)
+        buttonBottom.addTarget(self, action: #selector(AlertOnboarding.onClick), for: .touchUpInside)
         
-        self.background = UIView(frame: CGRect(x: 0,y: 0, width: 0, height: 0))
-        self.background.backgroundColor = UIColor.black
-        self.background.alpha = 0.0
+        background = UIView(frame: CGRect(x: 0,y: 0, width: 0, height: 0))
+        background.backgroundColor = UIColor.black
+        background.alpha = 0.0
         
         
-        self.clipsToBounds = true
-        self.layer.cornerRadius = 10
+        clipsToBounds = true
+        layer.cornerRadius = 10
     }
     
     
     fileprivate func configureConstraints(_ superView: UIView) {
         
-        self.translatesAutoresizingMaskIntoConstraints = false
-        self.buttonBottom.translatesAutoresizingMaskIntoConstraints = false
-        self.container.view.translatesAutoresizingMaskIntoConstraints = false
-        self.background.translatesAutoresizingMaskIntoConstraints = false
+        translatesAutoresizingMaskIntoConstraints = false
+        buttonBottom.translatesAutoresizingMaskIntoConstraints = false
+        container.view.translatesAutoresizingMaskIntoConstraints = false
+        background.translatesAutoresizingMaskIntoConstraints = false
         
-        self.removeConstraints(self.constraints)
-        self.buttonBottom.removeConstraints(self.buttonBottom.constraints)
-        self.container.view.removeConstraints(self.container.view.constraints)
+        removeConstraints(constraints)
+        buttonBottom.removeConstraints(buttonBottom.constraints)
+        container.view.removeConstraints(container.view.constraints)
         
         heightForAlertView = UIScreen.main.bounds.height*percentageRatioHeight
         widthForAlertView = UIScreen.main.bounds.width*percentageRatioWidth
         
         //Constraints for alertview
         let horizontalContraintsAlertView = NSLayoutConstraint(item: self, attribute: .centerXWithinMargins, relatedBy: .equal, toItem: superView, attribute: .centerXWithinMargins, multiplier: 1.0, constant: 0)
-        let verticalContraintsAlertView = NSLayoutConstraint(item: self, attribute:.centerYWithinMargins, relatedBy: .equal, toItem: superView, attribute: .centerYWithinMargins, multiplier: 1.0, constant: 0)
+        let verticalContraintsAlertView = NSLayoutConstraint(item: self, attribute: .centerYWithinMargins, relatedBy: .equal, toItem: superView, attribute: .centerYWithinMargins, multiplier: 1.0, constant: 0)
         let heightConstraintForAlertView = NSLayoutConstraint.init(item: self, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: heightForAlertView)
         let widthConstraintForAlertView = NSLayoutConstraint.init(item: self, attribute: .width, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: widthForAlertView)
         
         //Constraints for button
-        let verticalContraintsButtonBottom = NSLayoutConstraint(item: self.buttonBottom, attribute:.centerXWithinMargins, relatedBy: .equal, toItem: self, attribute: .centerXWithinMargins, multiplier: 1.0, constant: 0)
-        let heightConstraintForButtonBottom = NSLayoutConstraint.init(item: self.buttonBottom, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: heightForAlertView*0.1)
-        let widthConstraintForButtonBottom = NSLayoutConstraint.init(item: self.buttonBottom, attribute: .width, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: widthForAlertView)
-        let pinContraintsButtonBottom = NSLayoutConstraint(item: self.buttonBottom, attribute: .bottom, relatedBy: .equal, toItem: self, attribute: .bottom, multiplier: 1.0, constant: 0)
+        let verticalContraintsButtonBottom = NSLayoutConstraint(item: buttonBottom, attribute: .centerXWithinMargins, relatedBy: .equal, toItem: self, attribute: .centerXWithinMargins, multiplier: 1.0, constant: 0)
+        let heightConstraintForButtonBottom = NSLayoutConstraint.init(item: buttonBottom, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: heightForAlertView*0.1)
+        let widthConstraintForButtonBottom = NSLayoutConstraint.init(item: buttonBottom, attribute: .width, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: widthForAlertView)
+        let pinContraintsButtonBottom = NSLayoutConstraint(item: buttonBottom, attribute: .bottom, relatedBy: .equal, toItem: self, attribute: .bottom, multiplier: 1.0, constant: 0)
         
         //Constraints for container
-        let verticalContraintsForContainer = NSLayoutConstraint(item: self.container.view, attribute:.centerXWithinMargins, relatedBy: .equal, toItem: self, attribute: .centerXWithinMargins, multiplier: 1.0, constant: 0)
-        let heightConstraintForContainer = NSLayoutConstraint.init(item: self.container.view, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: heightForAlertView*0.9)
-        let widthConstraintForContainer = NSLayoutConstraint.init(item: self.container.view, attribute: .width, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: widthForAlertView)
-        let pinContraintsForContainer = NSLayoutConstraint(item: self.container.view, attribute: .top, relatedBy: .equal, toItem: self, attribute: .top, multiplier: 1.0, constant: 0)
+        let verticalContraintsForContainer = NSLayoutConstraint(item: container.view, attribute: .centerXWithinMargins, relatedBy: .equal, toItem: self, attribute: .centerXWithinMargins, multiplier: 1.0, constant: 0)
+        let heightConstraintForContainer = NSLayoutConstraint.init(item: container.view, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: heightForAlertView*0.9)
+        let widthConstraintForContainer = NSLayoutConstraint.init(item: container.view, attribute: .width, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: widthForAlertView)
+        let pinContraintsForContainer = NSLayoutConstraint(item: container.view, attribute: .top, relatedBy: .equal, toItem: self, attribute: .top, multiplier: 1.0, constant: 0)
         
         
         //Constraints for background
@@ -193,8 +193,8 @@ open class AlertOnboarding: UIView, AlertPageViewDelegate {
     
     //MARK: FOR ANIMATIONS
     fileprivate func animateForOpening() {
-        self.alpha = 1.0
-        self.transform = CGAffineTransform(scaleX: 0.3, y: 0.3)
+        alpha = 1.0
+        transform = CGAffineTransform(scaleX: 0.3, y: 0.3)
         UIView.animate(withDuration: 1, delay: 0.0, usingSpringWithDamping: 0.5, initialSpringVelocity: 0.5, options: [], animations: { [weak self] in
             guard let self = self else { return }
 

--- a/AlertOnboarding/AlertOnboarding.swift
+++ b/AlertOnboarding/AlertOnboarding.swift
@@ -74,7 +74,7 @@ open class AlertOnboarding: UIView, AlertPageViewDelegate {
     }
     
     //-----------------------------------------------------------------------------------------
-    // MARK: PUBLIC FUNCTIONS    --------------------------------------------------------------
+    // MARK: PUBLIC FUNCTIONS
     //-----------------------------------------------------------------------------------------
     
     open func show() {
@@ -115,7 +115,7 @@ open class AlertOnboarding: UIView, AlertPageViewDelegate {
     
     
     //------------------------------------------------------------------------------------------
-    // MARK: PRIVATE FUNCTIONS    --------------------------------------------------------------
+    // MARK: PRIVATE FUNCTIONS
     //------------------------------------------------------------------------------------------
     
     //MARK: Check if onboarding was skipped
@@ -130,7 +130,7 @@ open class AlertOnboarding: UIView, AlertPageViewDelegate {
     }
     
     
-    //MARK: FOR CONFIGURATION    --------------------------------------
+    //MARK: FOR CONFIGURATION
     fileprivate func configure(_ arrayOfImage: [String], arrayOfTitle: [String], arrayOfDescription: [String]) {
         
         self.buttonBottom = UIButton(frame: CGRect(x: 0,y: 0, width: 0, height: 0))
@@ -190,7 +190,7 @@ open class AlertOnboarding: UIView, AlertPageViewDelegate {
                                      widthContraintsForBackground, heightConstraintForBackground])
     }
     
-    //MARK: FOR ANIMATIONS ---------------------------------
+    //MARK: FOR ANIMATIONS
     fileprivate func animateForOpening(){
         self.alpha = 1.0
         self.transform = CGAffineTransform(scaleX: 0.3, y: 0.3)
@@ -217,19 +217,19 @@ open class AlertOnboarding: UIView, AlertPageViewDelegate {
         })
     }
     
-    //MARK: BUTTON ACTIONS ---------------------------------
+    //MARK: BUTTON ACTIONS
     
     @objc func onClick(){
         self.hide()
     }
     
-    //MARK: ALERTPAGEVIEWDELEGATE    --------------------------------------
+    //MARK: ALERTPAGEVIEWDELEGATE
     
     func nextStep(_ step: Int) {
         self.delegate?.alertOnboardingNext(step)
     }
     
-    //MARK: OTHERS    --------------------------------------
+    //MARK: OTHERS
     fileprivate func getTopViewController() -> UIViewController? {
         var topController: UIViewController? = UIApplication.shared.keyWindow?.rootViewController
         while topController?.presentedViewController != nil {
@@ -238,7 +238,7 @@ open class AlertOnboarding: UIView, AlertPageViewDelegate {
         return topController
     }
     
-    //MARK: NOTIFICATIONS PROCESS ------------------------------------------
+    //MARK: NOTIFICATIONS PROCESS
     fileprivate func interceptOrientationChange(){
         UIDevice.current.beginGeneratingDeviceOrientationNotifications()
         NotificationCenter.default.addObserver(self, selector: #selector(AlertOnboarding.onOrientationChange), name: UIDevice.orientationDidChangeNotification, object: nil)

--- a/AlertOnboarding/AlertOnboarding.swift
+++ b/AlertOnboarding/AlertOnboarding.swift
@@ -82,8 +82,8 @@ open class AlertOnboarding: UIView, AlertPageViewDelegate {
         //Update Color
         self.buttonBottom.backgroundColor = colorButtonBottomBackground
         self.backgroundColor = colorForAlertViewBackground
-        self.buttonBottom.setTitleColor(colorButtonText, for: UIControlState())
-        self.buttonBottom.setTitle(self.titleSkipButton, for: UIControlState())
+        self.buttonBottom.setTitleColor(colorButtonText, for: UIControl.State())
+        self.buttonBottom.setTitle(self.titleSkipButton, for: UIControl.State())
         
         self.container = AlertPageViewController(arrayOfImage: arrayOfImage, arrayOfTitle: arrayOfTitle, arrayOfDescription: arrayOfDescription, alertView: self)
         self.container.delegate = self
@@ -201,7 +201,7 @@ open class AlertOnboarding: UIView, AlertPageViewDelegate {
     }
     
     fileprivate func animateForEnding(){
-        UIView.animate(withDuration: 0.2, delay: 0.0, options: UIViewAnimationOptions.curveEaseOut, animations: {
+        UIView.animate(withDuration: 0.2, delay: 0.0, options: UIView.AnimationOptions.curveEaseOut, animations: {
             self.alpha = 0.0
             self.background.alpha = 0.0
             }, completion: {
@@ -211,7 +211,7 @@ open class AlertOnboarding: UIView, AlertPageViewDelegate {
                     () -> Void in
                     self.background.removeFromSuperview()
                     self.removeFromSuperview()
-                    self.container.removeFromParentViewController()
+                    self.container.removeFromParent()
                     self.container.view.removeFromSuperview()
                 }
         })
@@ -241,7 +241,7 @@ open class AlertOnboarding: UIView, AlertPageViewDelegate {
     //MARK: NOTIFICATIONS PROCESS ------------------------------------------
     fileprivate func interceptOrientationChange(){
         UIDevice.current.beginGeneratingDeviceOrientationNotifications()
-        NotificationCenter.default.addObserver(self, selector: #selector(AlertOnboarding.onOrientationChange), name: NSNotification.Name.UIDeviceOrientationDidChange, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(AlertOnboarding.onOrientationChange), name: UIDevice.orientationDidChangeNotification, object: nil)
     }
     
     @objc func onOrientationChange(){

--- a/AlertOnboarding/AlertOnboarding.swift
+++ b/AlertOnboarding/AlertOnboarding.swift
@@ -139,7 +139,7 @@ open class AlertOnboarding: UIView, AlertPageViewDelegate {
         
         self.background = UIView(frame: CGRect(x: 0,y: 0, width: 0, height: 0))
         self.background.backgroundColor = UIColor.black
-        self.background.alpha = 0.5
+        self.background.alpha = 0.0
         
         
         self.clipsToBounds = true
@@ -195,6 +195,7 @@ open class AlertOnboarding: UIView, AlertPageViewDelegate {
         self.alpha = 1.0
         self.transform = CGAffineTransform(scaleX: 0.3, y: 0.3)
         UIView.animate(withDuration: 1, delay: 0.0, usingSpringWithDamping: 0.5, initialSpringVelocity: 0.5, options: [], animations: {
+            self.background.alpha = 0.5
             self.transform = CGAffineTransform(scaleX: 1, y: 1)
             }, completion: nil)
     }

--- a/AlertOnboarding/AlertOnboarding.swift
+++ b/AlertOnboarding/AlertOnboarding.swift
@@ -15,87 +15,85 @@ public protocol AlertOnboardingDelegate {
 }
 
 open class AlertOnboarding: UIView, AlertPageViewDelegate {
-    
-    //FOR DATA  ------------------------
+
+    // FOR DATA  ------------------------
     fileprivate var arrayOfImage = [String]()
     fileprivate var arrayOfTitle = [String]()
     fileprivate var arrayOfDescription = [String]()
-    
-    //FOR DESIGN    ------------------------
+
+    // FOR DESIGN    ------------------------
     open var buttonBottom = UIButton()
 
     fileprivate var container: AlertPageViewController!
     open var background = UIView()
-    
-    
-    //PUBLIC VARS   ------------------------
+
+    // PUBLIC VARS   ------------------------
     open var colorForAlertViewBackground: UIColor = UIColor.white
-    
+
     open var colorButtonBottomBackground: UIColor = UIColor(red: 226/255, green: 237/255, blue: 248/255, alpha: 1.0)
     open var colorButtonText: UIColor = UIColor(red: 118/255, green: 125/255, blue: 152/255, alpha: 1.0)
-    
+
     open var colorTitleLabel: UIColor = UIColor(red: 171/255, green: 177/255, blue: 196/255, alpha: 1.0)
     open var colorDescriptionLabel: UIColor = UIColor(red: 171/255, green: 177/255, blue: 196/255, alpha: 1.0)
-    
+
     open var colorPageIndicator = UIColor(red: 171/255, green: 177/255, blue: 196/255, alpha: 1.0)
     open var colorCurrentPageIndicator = UIColor(red: 118/255, green: 125/255, blue: 152/255, alpha: 1.0)
-    
+
     open var heightForAlertView: CGFloat!
     open var widthForAlertView: CGFloat!
-    
+
     open var heightRatio: CGFloat = 0.8
     open var widthRatio: CGFloat = 0.8
-    
+
     open var titleSkipButton = "SKIP"
     open var titleGotItButton = "GOT IT !"
-    
+
     open var delegate: AlertOnboardingDelegate?
-    
-    
+
     public init (arrayOfImage: [String], arrayOfTitle: [String], arrayOfDescription: [String]) {
-        super.init(frame: CGRect(x: 0,y: 0,width: 0,height: 0))
+        super.init(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
         self.configure(arrayOfImage, arrayOfTitle: arrayOfTitle, arrayOfDescription: arrayOfDescription)
         self.arrayOfImage = arrayOfImage
         self.arrayOfTitle = arrayOfTitle
         self.arrayOfDescription = arrayOfDescription
-        
+
         self.interceptOrientationChange()
     }
-    
+
     override public init(frame: CGRect) {
         super.init(frame: frame)
     }
-    
+
     required public init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     override open func layoutSubviews() {
         super.layoutSubviews()
     }
-    
-    //-----------------------------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------------------------
     // MARK: PUBLIC FUNCTIONS
-    //-----------------------------------------------------------------------------------------
-    
+    // -----------------------------------------------------------------------------------------
+
     open func show() {
-        
-        //Update Color
+
+        // Update Color
         buttonBottom.backgroundColor = colorButtonBottomBackground
         backgroundColor = colorForAlertViewBackground
         buttonBottom.setTitleColor(colorButtonText, for: UIControl.State())
         buttonBottom.setTitle(titleSkipButton, for: UIControl.State())
-        
+
         container = AlertPageViewController(arrayOfImage: arrayOfImage, arrayOfTitle: arrayOfTitle, arrayOfDescription: arrayOfDescription, alertView: self)
         container.delegate = self
         insertSubview(container.view, aboveSubview: self)
         insertSubview(buttonBottom, aboveSubview: self)
-        
+
         // Only show once
         if superview != nil {
             return
         }
-        
+
         // Find current stop viewcontroller
         if let topController = getTopViewController() {
             let superView: UIView = topController.view
@@ -105,93 +103,87 @@ open class AlertOnboarding: UIView, AlertPageViewDelegate {
             animateForOpening()
         }
     }
-    
-    //Hide onboarding with animation
-    open func hide(){
+
+    // Hide onboarding with animation
+    open func hide() {
         checkIfOnboardingWasSkipped()
         DispatchQueue.main.async { [weak self] in
             self?.animateForEnding()
         }
     }
-    
-    
-    //------------------------------------------------------------------------------------------
+
+    // ------------------------------------------------------------------------------------------
     // MARK: PRIVATE FUNCTIONS
-    //------------------------------------------------------------------------------------------
-    
-    //MARK: Check if onboarding was skipped
-    fileprivate func checkIfOnboardingWasSkipped(){
+    // ------------------------------------------------------------------------------------------
+
+    // MARK: Check if onboarding was skipped
+    fileprivate func checkIfOnboardingWasSkipped() {
         let currentStep = container.currentStep
-        if currentStep < (container.arrayOfImage.count - 1) && !container.isCompleted{
+        if currentStep < (container.arrayOfImage.count - 1) && !container.isCompleted {
             delegate?.alertOnboardingSkipped(currentStep, maxStep: container.maxStep)
-        }
-        else {
+        } else {
             delegate?.alertOnboardingCompleted()
         }
     }
-    
-    
-    //MARK: FOR CONFIGURATION
+
+    // MARK: FOR CONFIGURATION
     fileprivate func configure(_ arrayOfImage: [String], arrayOfTitle: [String], arrayOfDescription: [String]) {
-        
-        buttonBottom = UIButton(frame: CGRect(x: 0,y: 0, width: 0, height: 0))
+
+        buttonBottom = UIButton(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
         buttonBottom.titleLabel?.font = UIFont(name: "Avenir-Black", size: 15)
         buttonBottom.addTarget(self, action: #selector(AlertOnboarding.onClick), for: .touchUpInside)
-        
-        background = UIView(frame: CGRect(x: 0,y: 0, width: 0, height: 0))
+
+        background = UIView(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
         background.backgroundColor = UIColor.black
         background.alpha = 0.0
-        
-        
+
         clipsToBounds = true
         layer.cornerRadius = 10
     }
-    
-    
+
     fileprivate func configureConstraints(_ superView: UIView) {
-        
+
         translatesAutoresizingMaskIntoConstraints = false
         buttonBottom.translatesAutoresizingMaskIntoConstraints = false
         container.view.translatesAutoresizingMaskIntoConstraints = false
         background.translatesAutoresizingMaskIntoConstraints = false
-        
+
         removeConstraints(constraints)
         buttonBottom.removeConstraints(buttonBottom.constraints)
         container.view.removeConstraints(container.view.constraints)
-        
+
         heightForAlertView = UIScreen.main.bounds.height * heightRatio
         widthForAlertView = UIScreen.main.bounds.width * widthRatio
-        
-        //Constraints for alertview
+
+        // Constraints for alertview
         let horizontalContraintsAlertView = NSLayoutConstraint(item: self, attribute: .centerXWithinMargins, relatedBy: .equal, toItem: superView, attribute: .centerXWithinMargins, multiplier: 1.0, constant: 0)
         let verticalContraintsAlertView = NSLayoutConstraint(item: self, attribute: .centerYWithinMargins, relatedBy: .equal, toItem: superView, attribute: .centerYWithinMargins, multiplier: 1.0, constant: 0)
         let heightConstraintForAlertView = NSLayoutConstraint.init(item: self, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: heightForAlertView)
         let widthConstraintForAlertView = NSLayoutConstraint.init(item: self, attribute: .width, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: widthForAlertView)
-        
-        //Constraints for button
+
+        // Constraints for button
         let verticalContraintsButtonBottom = NSLayoutConstraint(item: buttonBottom, attribute: .centerXWithinMargins, relatedBy: .equal, toItem: self, attribute: .centerXWithinMargins, multiplier: 1.0, constant: 0)
         let heightConstraintForButtonBottom = NSLayoutConstraint.init(item: buttonBottom, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: heightForAlertView*0.1)
         let widthConstraintForButtonBottom = NSLayoutConstraint.init(item: buttonBottom, attribute: .width, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: widthForAlertView)
         let pinContraintsButtonBottom = NSLayoutConstraint(item: buttonBottom, attribute: .bottom, relatedBy: .equal, toItem: self, attribute: .bottom, multiplier: 1.0, constant: 0)
-        
-        //Constraints for container
+
+        // Constraints for container
         let verticalContraintsForContainer = NSLayoutConstraint(item: container.view, attribute: .centerXWithinMargins, relatedBy: .equal, toItem: self, attribute: .centerXWithinMargins, multiplier: 1.0, constant: 0)
         let heightConstraintForContainer = NSLayoutConstraint.init(item: container.view, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: heightForAlertView*0.9)
         let widthConstraintForContainer = NSLayoutConstraint.init(item: container.view, attribute: .width, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: widthForAlertView)
         let pinContraintsForContainer = NSLayoutConstraint(item: container.view, attribute: .top, relatedBy: .equal, toItem: self, attribute: .top, multiplier: 1.0, constant: 0)
-        
-        
-        //Constraints for background
-        let widthContraintsForBackground = NSLayoutConstraint(item: background, attribute:.width, relatedBy: .equal, toItem: superView, attribute: .width, multiplier: 1, constant: 0)
+
+        // Constraints for background
+        let widthContraintsForBackground = NSLayoutConstraint(item: background, attribute: .width, relatedBy: .equal, toItem: superView, attribute: .width, multiplier: 1, constant: 0)
         let heightConstraintForBackground = NSLayoutConstraint.init(item: background, attribute: .height, relatedBy: .equal, toItem: superView, attribute: .height, multiplier: 1, constant: 0)
-        
-        NSLayoutConstraint.activate([horizontalContraintsAlertView, verticalContraintsAlertView,heightConstraintForAlertView, widthConstraintForAlertView,
+
+        NSLayoutConstraint.activate([horizontalContraintsAlertView, verticalContraintsAlertView, heightConstraintForAlertView, widthConstraintForAlertView,
                                      verticalContraintsButtonBottom, heightConstraintForButtonBottom, widthConstraintForButtonBottom, pinContraintsButtonBottom,
                                      verticalContraintsForContainer, heightConstraintForContainer, widthConstraintForContainer, pinContraintsForContainer,
                                      widthContraintsForBackground, heightConstraintForBackground])
     }
-    
-    //MARK: FOR ANIMATIONS
+
+    // MARK: FOR ANIMATIONS
     fileprivate func animateForOpening() {
         alpha = 1.0
         transform = CGAffineTransform(scaleX: 0.3, y: 0.3)
@@ -202,14 +194,14 @@ open class AlertOnboarding: UIView, AlertPageViewDelegate {
             self.transform = CGAffineTransform(scaleX: 1, y: 1)
             }, completion: nil)
     }
-    
+
     fileprivate func animateForEnding() {
         UIView.animate(withDuration: 0.2, delay: 0.0, options: UIView.AnimationOptions.curveEaseOut, animations: { [weak self] in
             guard let self = self else { return }
 
             self.alpha = 0.0
             self.background.alpha = 0.0
-            }, completion: { [weak self] finished in
+            }, completion: { [weak self] _ in
                 DispatchQueue.main.async { [weak self] in
                     self?.endingAnimationCompleted()
                 }
@@ -222,20 +214,20 @@ open class AlertOnboarding: UIView, AlertPageViewDelegate {
         container.removeFromParent()
         container.view.removeFromSuperview()
     }
-    
-    //MARK: BUTTON ACTIONS
-    
+
+    // MARK: BUTTON ACTIONS
+
     @objc func onClick() {
         hide()
     }
-    
-    //MARK: ALERTPAGEVIEWDELEGATE
-    
+
+    // MARK: ALERTPAGEVIEWDELEGATE
+
     func nextStep(_ step: Int) {
         delegate?.alertOnboardingNext(step)
     }
-    
-    //MARK: OTHERS
+
+    // MARK: OTHERS
     fileprivate func getTopViewController() -> UIViewController? {
         var topController: UIViewController? = UIApplication.shared.keyWindow?.rootViewController
         while topController?.presentedViewController != nil {
@@ -243,14 +235,14 @@ open class AlertOnboarding: UIView, AlertPageViewDelegate {
         }
         return topController
     }
-    
-    //MARK: NOTIFICATIONS PROCESS
-    fileprivate func interceptOrientationChange(){
+
+    // MARK: NOTIFICATIONS PROCESS
+    fileprivate func interceptOrientationChange() {
         UIDevice.current.beginGeneratingDeviceOrientationNotifications()
         NotificationCenter.default.addObserver(self, selector: #selector(onOrientationChange), name: UIDevice.orientationDidChangeNotification, object: nil)
     }
-    
-    @objc func onOrientationChange(){
+
+    @objc func onOrientationChange() {
         if let superview = superview {
             configureConstraints(superview)
             container.configureConstraintsForPageControl()

--- a/AlertOnboarding/AlertOnboarding.swift
+++ b/AlertOnboarding/AlertOnboarding.swift
@@ -43,8 +43,8 @@ open class AlertOnboarding: UIView, AlertPageViewDelegate {
     open var heightForAlertView: CGFloat!
     open var widthForAlertView: CGFloat!
     
-    open var percentageRatioHeight: CGFloat = 0.8
-    open var percentageRatioWidth: CGFloat = 0.8
+    open var heightRatio: CGFloat = 0.8
+    open var widthRatio: CGFloat = 0.8
     
     open var titleSkipButton = "SKIP"
     open var titleGotItButton = "GOT IT !"
@@ -159,8 +159,8 @@ open class AlertOnboarding: UIView, AlertPageViewDelegate {
         buttonBottom.removeConstraints(buttonBottom.constraints)
         container.view.removeConstraints(container.view.constraints)
         
-        heightForAlertView = UIScreen.main.bounds.height*percentageRatioHeight
-        widthForAlertView = UIScreen.main.bounds.width*percentageRatioWidth
+        heightForAlertView = UIScreen.main.bounds.height * heightRatio
+        widthForAlertView = UIScreen.main.bounds.width * widthRatio
         
         //Constraints for alertview
         let horizontalContraintsAlertView = NSLayoutConstraint(item: self, attribute: .centerXWithinMargins, relatedBy: .equal, toItem: superView, attribute: .centerXWithinMargins, multiplier: 1.0, constant: 0)

--- a/AlertOnboarding/AlertOnboarding.swift
+++ b/AlertOnboarding/AlertOnboarding.swift
@@ -210,20 +210,17 @@ open class AlertOnboarding: UIView, AlertPageViewDelegate {
             self.alpha = 0.0
             self.background.alpha = 0.0
             }, completion: { [weak self] finished in
-                // On main thread
-                self?.endingAnimationCompleted()
+                DispatchQueue.main.async { [weak self] in
+                    self?.endingAnimationCompleted()
+                }
         })
     }
 
     private func endingAnimationCompleted() {
-        DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
-
-            self.background.removeFromSuperview()
-            self.removeFromSuperview()
-            self.container.removeFromParent()
-            self.container.view.removeFromSuperview()
-        }
+        background.removeFromSuperview()
+        removeFromSuperview()
+        container.removeFromParent()
+        container.view.removeFromSuperview()
     }
     
     //MARK: BUTTON ACTIONS

--- a/AlertOnboarding/AlertPageViewController.swift
+++ b/AlertOnboarding/AlertPageViewController.swift
@@ -53,7 +53,7 @@ class AlertPageViewController: UIViewController, UIPageViewControllerDataSource,
         self.view.backgroundColor = UIColor.clear
         self.view.addSubview(self.pageController.view)
         self.view.addSubview(self.pageControl)
-        self.pageController.didMove(toParentViewController: self)
+        self.pageController.didMove(toParent: self)
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -140,9 +140,9 @@ class AlertPageViewController: UIViewController, UIPageViewControllerDataSource,
         if pageControl != nil {
             pageControl.currentPage = arrayOfImage.count - index! - 1
             if pageControl.currentPage == arrayOfImage.count - 1 {
-                self.alertview.buttonBottom.setTitle(alertview.titleGotItButton, for: UIControlState())
+                self.alertview.buttonBottom.setTitle(alertview.titleGotItButton, for: UIControl.State())
             } else {
-                self.alertview.buttonBottom.setTitle(alertview.titleSkipButton, for: UIControlState())
+                self.alertview.buttonBottom.setTitle(alertview.titleSkipButton, for: UIControl.State())
             }
         }
     }
@@ -170,7 +170,7 @@ class AlertPageViewController: UIViewController, UIPageViewControllerDataSource,
     }
     
     fileprivate func configurePageViewController(){
-        self.pageController = UIPageViewController(transitionStyle: UIPageViewControllerTransitionStyle.scroll, navigationOrientation: UIPageViewControllerNavigationOrientation.horizontal, options: nil)
+        self.pageController = UIPageViewController(transitionStyle: UIPageViewController.TransitionStyle.scroll, navigationOrientation: UIPageViewController.NavigationOrientation.horizontal, options: nil)
         self.pageController.view.backgroundColor = UIColor.clear
         
         if #available(iOS 9.0, *) {
@@ -189,7 +189,7 @@ class AlertPageViewController: UIViewController, UIPageViewControllerDataSource,
         self.viewControllers = [initialViewController!]
         self.pageController.setViewControllers(viewControllers, direction: .forward, animated: false, completion: nil)
         
-        self.addChildViewController(self.pageController)
+        self.addChild(self.pageController)
     }
     
     //MARK: Called after notification orientation changement

--- a/AlertOnboarding/AlertPageViewController.swift
+++ b/AlertOnboarding/AlertPageViewController.swift
@@ -13,8 +13,8 @@ protocol AlertPageViewDelegate {
 }
 
 class AlertPageViewController: UIViewController, UIPageViewControllerDataSource, UIPageViewControllerDelegate {
-    
-    //FOR DESIGN
+
+    // FOR DESIGN
     var pageController: UIPageViewController = {
         let pageController = UIPageViewController(transitionStyle: .scroll, navigationOrientation: .horizontal, options: nil)
         pageController.view.backgroundColor = .clear
@@ -22,29 +22,28 @@ class AlertPageViewController: UIViewController, UIPageViewControllerDataSource,
     }()
 
     var pageControl: UIPageControl = {
-        let pageControl = UIPageControl(frame: CGRect(x: 0,y: 0,width: 0,height: 0))
+        let pageControl = UIPageControl(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
         pageControl.backgroundColor = UIColor.clear
-        
+
         pageControl.currentPage = 0
         pageControl.isEnabled = false
         return pageControl
     }()
-    
+
     var alertview: AlertOnboarding
-    
-    //FOR DATA
+
+    // FOR DATA
     var arrayOfImage: [String]
     var arrayOfTitle: [String]
     var arrayOfDescription: [String]
     var viewControllers = [UIViewController]()
-    
-    //FOR TRACKING USER USAGE
+
+    // FOR TRACKING USER USAGE
     var currentStep = 0
     var maxStep = 0
     var isCompleted = false
     var delegate: AlertPageViewDelegate?
-    
-    
+
     init (arrayOfImage: [String], arrayOfTitle: [String], arrayOfDescription: [String], alertView: AlertOnboarding) {
         self.arrayOfImage = arrayOfImage
         self.arrayOfTitle = arrayOfTitle
@@ -53,97 +52,95 @@ class AlertPageViewController: UIViewController, UIPageViewControllerDataSource,
 
         super.init(nibName: nil, bundle: nil)
     }
-    
+
     required init(coder: NSCoder) {
         fatalError("NSCoding not supported")
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         configurePageViewController()
         configurePageControl()
-        
+
         view.backgroundColor = UIColor.clear
         view.addSubview(pageController.view)
         view.addSubview(pageControl)
         pageController.didMove(toParent: self)
     }
-    
+
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
     }
-    
+
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
     }
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
     }
-    
-    
+
     func pageViewController(_ pageViewController: UIPageViewController, viewControllerAfter viewController: UIViewController) -> UIViewController? {
         guard let viewController = viewController as? AlertChildPageViewController else {
             return nil
         }
-        
+
         var index = viewController.pageIndex
-        
-        if(index == 0){
+
+        if index == 0 {
             return nil
         }
-        
+
         index -= 1
         return viewControllerAtIndex(index)
     }
-    
+
     func pageViewController(_ pageViewController: UIPageViewController, viewControllerBefore viewController: UIViewController) -> UIViewController? {
         guard let viewController = viewController as? AlertChildPageViewController else {
             return nil
         }
-        
+
         var index = viewController.pageIndex
-        
+
         index += 1
-        
-        if(index == arrayOfImage.count){
+
+        if index == arrayOfImage.count {
             return nil
         }
-        
+
         return viewControllerAtIndex(index)
     }
-    
-    
-    func viewControllerAtIndex(_ index : Int) -> UIViewController? {
-        
+
+    func viewControllerAtIndex(_ index: Int) -> UIViewController? {
+
         var pageContentViewController: AlertChildPageViewController!
         let podBundle = Bundle(for: classForCoder)
-        
-        //FROM COCOAPOD
+
+        // FROM COCOAPOD
         if let bundleURL = podBundle.url(forResource: "AlertOnboardingXib", withExtension: "bundle") {
             if let bundle = Bundle(url: bundleURL) {
                 pageContentViewController = UINib(nibName: "AlertChildPageViewController", bundle: bundle).instantiate(withOwner: nil, options: nil)[0] as? AlertChildPageViewController
             } else {
                 assertionFailure("Could not load the bundle.. Please re-install AlertOnboarding via Cocoapod or install it manually.")
             }
-            //FROM MANUAL INSTALL
+            // FROM MANUAL INSTALL
         } else {
             pageContentViewController = UINib(nibName: "AlertChildPageViewController", bundle: nil).instantiate(withOwner: nil, options: nil)[0] as? AlertChildPageViewController
         }
-        
+
         pageContentViewController.pageIndex = index // 0
-        
+
         let realIndex = arrayOfImage.count - index - 1
-        
+
         pageContentViewController.image.image = UIImage(named: arrayOfImage[realIndex])
         pageContentViewController.labelMainTitle.text = arrayOfTitle[realIndex]
         pageContentViewController.labelMainTitle.textColor = alertview.colorTitleLabel
         pageContentViewController.labelDescription.text = arrayOfDescription[realIndex]
         pageContentViewController.labelDescription.textColor = alertview.colorDescriptionLabel
-        
+
         return pageContentViewController
     }
-    
+
     func pageViewController(_ pageViewController: UIPageViewController, didFinishAnimating finished: Bool, previousViewControllers: [UIViewController], transitionCompleted completed: Bool) {
         guard let controllers = pageViewController.viewControllers, !controllers.isEmpty else { return }
         guard let pageContentViewController = controllers[0] as? AlertChildPageViewController else { return }
@@ -151,15 +148,15 @@ class AlertPageViewController: UIViewController, UIPageViewControllerDataSource,
         let index = pageContentViewController.pageIndex
         currentStep = (arrayOfImage.count - index - 1)
         delegate?.nextStep(currentStep)
-        //Check if user watching the last step
+        // Check if user watching the last step
         if currentStep == arrayOfImage.count - 1 {
             isCompleted = true
         }
-        //Remember the last screen user have seen
+        // Remember the last screen user have seen
         if currentStep > maxStep {
             maxStep = currentStep
         }
-        
+
         pageControl.currentPage = arrayOfImage.count - index - 1
         if pageControl.currentPage == arrayOfImage.count - 1 {
             alertview.buttonBottom.setTitle(alertview.titleGotItButton, for: UIControl.State())
@@ -167,25 +164,25 @@ class AlertPageViewController: UIViewController, UIPageViewControllerDataSource,
             alertview.buttonBottom.setTitle(alertview.titleSkipButton, for: UIControl.State())
         }
     }
-    
+
     func presentationCount(for pageViewController: UIPageViewController) -> Int {
         return arrayOfImage.count
     }
-    
+
     func presentationIndex(for pageViewController: UIPageViewController) -> Int {
         return 0
     }
-    
-    //MARK: CONFIGURATION ---------------------------------------------------------------------------------
+
+    // MARK: CONFIGURATION ---------------------------------------------------------------------------------
     fileprivate func configurePageControl() {
         pageControl.pageIndicatorTintColor = alertview.colorPageIndicator
         pageControl.currentPageIndicatorTintColor = alertview.colorCurrentPageIndicator
         pageControl.numberOfPages = arrayOfImage.count
-        
+
         configureConstraintsForPageControl()
     }
-    
-    fileprivate func configurePageViewController(){
+
+    fileprivate func configurePageViewController() {
         if #available(iOS 9.0, *) {
             let pageControl = UIPageControl.appearance(whenContainedInInstancesOf: [AlertPageViewController.self])
             pageControl.pageIndicatorTintColor = UIColor.clear
@@ -193,18 +190,18 @@ class AlertPageViewController: UIViewController, UIPageViewControllerDataSource,
         } else {
             // Fallback on earlier versions
         }
-        
+
         pageController.dataSource = self
         pageController.delegate = self
-        
+
         let initialViewController = viewControllerAtIndex(arrayOfImage.count-1)
         viewControllers = [initialViewController!]
         pageController.setViewControllers(viewControllers, direction: .forward, animated: false, completion: nil)
-        
+
         addChild(pageController)
     }
-    
-    //MARK: Called after notification orientation changement
+
+    // MARK: Called after notification orientation changement
     func configureConstraintsForPageControl() {
         let alertViewSizeHeight = UIScreen.main.bounds.height*alertview.heightRatio
         let positionX = alertViewSizeHeight - (alertViewSizeHeight * 0.1) - 50

--- a/AlertOnboarding/AlertPageViewController.swift
+++ b/AlertOnboarding/AlertPageViewController.swift
@@ -61,13 +61,13 @@ class AlertPageViewController: UIViewController, UIPageViewControllerDataSource,
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        self.configurePageViewController()
-        self.configurePageControl()
+        configurePageViewController()
+        configurePageControl()
         
-        self.view.backgroundColor = UIColor.clear
-        self.view.addSubview(self.pageController.view)
-        self.view.addSubview(self.pageControl)
-        self.pageController.didMove(toParent: self)
+        view.backgroundColor = UIColor.clear
+        view.addSubview(pageController.view)
+        view.addSubview(pageControl)
+        pageController.didMove(toParent: self)
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -91,7 +91,7 @@ class AlertPageViewController: UIViewController, UIPageViewControllerDataSource,
         }
         
         index -= 1
-        return self.viewControllerAtIndex(index)
+        return viewControllerAtIndex(index)
     }
     
     func pageViewController(_ pageViewController: UIPageViewController, viewControllerBefore viewController: UIViewController) -> UIViewController? {
@@ -104,14 +104,14 @@ class AlertPageViewController: UIViewController, UIPageViewControllerDataSource,
             return nil
         }
         
-        return self.viewControllerAtIndex(index)
+        return viewControllerAtIndex(index)
     }
     
     
     func viewControllerAtIndex(_ index : Int) -> UIViewController? {
         
         var pageContentViewController: AlertChildPageViewController!
-        let podBundle = Bundle(for: self.classForCoder)
+        let podBundle = Bundle(for: classForCoder)
         
         //FROM COCOAPOD
         if let bundleURL = podBundle.url(forResource: "AlertOnboardingXib", withExtension: "bundle") {
@@ -143,11 +143,11 @@ class AlertPageViewController: UIViewController, UIPageViewControllerDataSource,
         guard let pageContentViewController = controllers[0] as? AlertChildPageViewController else { return }
 
         let index = pageContentViewController.pageIndex
-        self.currentStep = (arrayOfImage.count - index - 1)
-        self.delegate?.nextStep(self.currentStep)
+        currentStep = (arrayOfImage.count - index - 1)
+        delegate?.nextStep(currentStep)
         //Check if user watching the last step
         if currentStep == arrayOfImage.count - 1 {
-            self.isCompleted = true
+            isCompleted = true
         }
         //Remember the last screen user have seen
         if currentStep > self.maxStep {
@@ -156,9 +156,9 @@ class AlertPageViewController: UIViewController, UIPageViewControllerDataSource,
         
         pageControl.currentPage = arrayOfImage.count - index - 1
         if pageControl.currentPage == arrayOfImage.count - 1 {
-            self.alertview.buttonBottom.setTitle(alertview.titleGotItButton, for: UIControl.State())
+            alertview.buttonBottom.setTitle(alertview.titleGotItButton, for: UIControl.State())
         } else {
-            self.alertview.buttonBottom.setTitle(alertview.titleSkipButton, for: UIControl.State())
+            alertview.buttonBottom.setTitle(alertview.titleSkipButton, for: UIControl.State())
         }
     }
     
@@ -193,8 +193,8 @@ class AlertPageViewController: UIViewController, UIPageViewControllerDataSource,
         pageController.dataSource = self
         pageController.delegate = self
         
-        let initialViewController = self.viewControllerAtIndex(arrayOfImage.count-1)
-        self.viewControllers = [initialViewController!]
+        let initialViewController = viewControllerAtIndex(arrayOfImage.count-1)
+        viewControllers = [initialViewController!]
         pageController.setViewControllers(viewControllers, direction: .forward, animated: false, completion: nil)
         
         self.addChild(pageController)
@@ -204,6 +204,6 @@ class AlertPageViewController: UIViewController, UIPageViewControllerDataSource,
     func configureConstraintsForPageControl() {
         let alertViewSizeHeight = UIScreen.main.bounds.height*alertview.heightRatio
         let positionX = alertViewSizeHeight - (alertViewSizeHeight * 0.1) - 50
-        self.pageControl.frame = CGRect(x: 0, y: positionX, width: self.view.bounds.width, height: 50)
+        pageControl.frame = CGRect(x: 0, y: positionX, width: view.bounds.width, height: 50)
     }
 }

--- a/AlertOnboarding/AlertPageViewController.swift
+++ b/AlertOnboarding/AlertPageViewController.swift
@@ -21,7 +21,15 @@ class AlertPageViewController: UIViewController, UIPageViewControllerDataSource,
         return pageController
     }()
 
-    var pageControl: UIPageControl!
+    var pageControl: UIPageControl = {
+        let pageControl = UIPageControl(frame: CGRect(x: 0,y: 0,width: 0,height: 0))
+        pageControl.backgroundColor = UIColor.clear
+        
+        pageControl.currentPage = 0
+        pageControl.isEnabled = false
+        return pageControl
+    }()
+    
     var alertview: AlertOnboarding
     
     //FOR DATA
@@ -145,13 +153,12 @@ class AlertPageViewController: UIViewController, UIPageViewControllerDataSource,
         if currentStep > self.maxStep {
             self.maxStep = currentStep
         }
-        if pageControl != nil {
-            pageControl.currentPage = arrayOfImage.count - index - 1
-            if pageControl.currentPage == arrayOfImage.count - 1 {
-                self.alertview.buttonBottom.setTitle(alertview.titleGotItButton, for: UIControl.State())
-            } else {
-                self.alertview.buttonBottom.setTitle(alertview.titleSkipButton, for: UIControl.State())
-            }
+        
+        pageControl.currentPage = arrayOfImage.count - index - 1
+        if pageControl.currentPage == arrayOfImage.count - 1 {
+            self.alertview.buttonBottom.setTitle(alertview.titleGotItButton, for: UIControl.State())
+        } else {
+            self.alertview.buttonBottom.setTitle(alertview.titleSkipButton, for: UIControl.State())
         }
     }
     
@@ -166,15 +173,11 @@ class AlertPageViewController: UIViewController, UIPageViewControllerDataSource,
     
     //MARK: CONFIGURATION ---------------------------------------------------------------------------------
     fileprivate func configurePageControl() {
-        self.pageControl = UIPageControl(frame: CGRect(x: 0,y: 0,width: 0,height: 0))
-        self.pageControl.backgroundColor = UIColor.clear
-        self.pageControl.pageIndicatorTintColor = alertview.colorPageIndicator
-        self.pageControl.currentPageIndicatorTintColor = alertview.colorCurrentPageIndicator
-        self.pageControl.numberOfPages = arrayOfImage.count
-        self.pageControl.currentPage = 0
-        self.pageControl.isEnabled = false
+        pageControl.pageIndicatorTintColor = alertview.colorPageIndicator
+        pageControl.currentPageIndicatorTintColor = alertview.colorCurrentPageIndicator
+        pageControl.numberOfPages = arrayOfImage.count
         
-        self.configureConstraintsForPageControl()
+        configureConstraintsForPageControl()
     }
     
     fileprivate func configurePageViewController(){

--- a/AlertOnboarding/AlertPageViewController.swift
+++ b/AlertOnboarding/AlertPageViewController.swift
@@ -15,9 +15,14 @@ protocol AlertPageViewDelegate {
 class AlertPageViewController: UIViewController, UIPageViewControllerDataSource, UIPageViewControllerDelegate {
     
     //FOR DESIGN
-    var pageController: UIPageViewController!
+    var pageController: UIPageViewController = {
+        let pageController = UIPageViewController(transitionStyle: .scroll, navigationOrientation: .horizontal, options: nil)
+        pageController.view.backgroundColor = .clear
+        return pageController
+    }()
+
     var pageControl: UIPageControl!
-    var alertview: AlertOnboarding!
+    var alertview: AlertOnboarding
     
     //FOR DATA
     var arrayOfImage: [String]
@@ -36,9 +41,9 @@ class AlertPageViewController: UIViewController, UIPageViewControllerDataSource,
         self.arrayOfImage = arrayOfImage
         self.arrayOfTitle = arrayOfTitle
         self.arrayOfDescription = arrayOfDescription
+        self.alertview = alertView
 
         super.init(nibName: nil, bundle: nil)
-        self.alertview = alertView
     }
     
     required init(coder: NSCoder) {
@@ -171,9 +176,6 @@ class AlertPageViewController: UIViewController, UIPageViewControllerDataSource,
     }
     
     fileprivate func configurePageViewController(){
-        self.pageController = UIPageViewController(transitionStyle: UIPageViewController.TransitionStyle.scroll, navigationOrientation: UIPageViewController.NavigationOrientation.horizontal, options: nil)
-        self.pageController.view.backgroundColor = UIColor.clear
-        
         if #available(iOS 9.0, *) {
             let pageControl = UIPageControl.appearance(whenContainedInInstancesOf: [AlertPageViewController.self])
             pageControl.pageIndicatorTintColor = UIColor.clear
@@ -183,14 +185,14 @@ class AlertPageViewController: UIViewController, UIPageViewControllerDataSource,
             // Fallback on earlier versions
         }
         
-        self.pageController.dataSource = self
-        self.pageController.delegate = self
+        pageController.dataSource = self
+        pageController.delegate = self
         
         let initialViewController = self.viewControllerAtIndex(arrayOfImage.count-1)
         self.viewControllers = [initialViewController!]
-        self.pageController.setViewControllers(viewControllers, direction: .forward, animated: false, completion: nil)
+        pageController.setViewControllers(viewControllers, direction: .forward, animated: false, completion: nil)
         
-        self.addChild(self.pageController)
+        self.addChild(pageController)
     }
     
     //MARK: Called after notification orientation changement

--- a/AlertOnboarding/AlertPageViewController.swift
+++ b/AlertOnboarding/AlertPageViewController.swift
@@ -76,7 +76,7 @@ class AlertPageViewController: UIViewController, UIPageViewControllerDataSource,
     
     func pageViewController(_ pageViewController: UIPageViewController, viewControllerAfter viewController: UIViewController) -> UIViewController? {
         
-        var index = (viewController as! AlertChildPageViewController).pageIndex!
+        var index = (viewController as! AlertChildPageViewController).pageIndex
         
         if(index == 0){
             return nil
@@ -88,7 +88,7 @@ class AlertPageViewController: UIViewController, UIPageViewControllerDataSource,
     
     func pageViewController(_ pageViewController: UIPageViewController, viewControllerBefore viewController: UIViewController) -> UIViewController? {
         
-        var index = (viewController as! AlertChildPageViewController).pageIndex!
+        var index = (viewController as! AlertChildPageViewController).pageIndex
         
         index += 1
         
@@ -133,7 +133,7 @@ class AlertPageViewController: UIViewController, UIPageViewControllerDataSource,
     func pageViewController(_ pageViewController: UIPageViewController, didFinishAnimating finished: Bool, previousViewControllers: [UIViewController], transitionCompleted completed: Bool) {
         let pageContentViewController = pageViewController.viewControllers![0] as! AlertChildPageViewController
         let index = pageContentViewController.pageIndex
-        self.currentStep = (arrayOfImage.count - index! - 1)
+        self.currentStep = (arrayOfImage.count - index - 1)
         self.delegate?.nextStep(self.currentStep)
         //Check if user watching the last step
         if currentStep == arrayOfImage.count - 1 {
@@ -144,7 +144,7 @@ class AlertPageViewController: UIViewController, UIPageViewControllerDataSource,
             self.maxStep = currentStep
         }
         if pageControl != nil {
-            pageControl.currentPage = arrayOfImage.count - index! - 1
+            pageControl.currentPage = arrayOfImage.count - index - 1
             if pageControl.currentPage == arrayOfImage.count - 1 {
                 self.alertview.buttonBottom.setTitle(alertview.titleGotItButton, for: UIControl.State())
             } else {

--- a/AlertOnboarding/AlertPageViewController.swift
+++ b/AlertOnboarding/AlertPageViewController.swift
@@ -108,13 +108,13 @@ class AlertPageViewController: UIViewController, UIPageViewControllerDataSource,
         //FROM COCOAPOD
         if let bundleURL = podBundle.url(forResource: "AlertOnboardingXib", withExtension: "bundle") {
             if let bundle = Bundle(url: bundleURL) {
-                pageContentViewController = UINib(nibName: "AlertChildPageViewController", bundle: bundle).instantiate(withOwner: nil, options: nil)[0] as! AlertChildPageViewController
+                pageContentViewController = UINib(nibName: "AlertChildPageViewController", bundle: bundle).instantiate(withOwner: nil, options: nil)[0] as? AlertChildPageViewController
             } else {
                 assertionFailure("Could not load the bundle.. Please re-install AlertOnboarding via Cocoapod or install it manually.")
             }
             //FROM MANUAL INSTALL
-        }else {
-            pageContentViewController = UINib(nibName: "AlertChildPageViewController", bundle: nil).instantiate(withOwner: nil, options: nil)[0] as! AlertChildPageViewController
+        } else {
+            pageContentViewController = UINib(nibName: "AlertChildPageViewController", bundle: nil).instantiate(withOwner: nil, options: nil)[0] as? AlertChildPageViewController
         }
         
         pageContentViewController.pageIndex = index // 0
@@ -131,7 +131,9 @@ class AlertPageViewController: UIViewController, UIPageViewControllerDataSource,
     }
     
     func pageViewController(_ pageViewController: UIPageViewController, didFinishAnimating finished: Bool, previousViewControllers: [UIViewController], transitionCompleted completed: Bool) {
-        let pageContentViewController = pageViewController.viewControllers![0] as! AlertChildPageViewController
+        guard let controllers = pageViewController.viewControllers, !controllers.isEmpty else { return }
+        guard let pageContentViewController = controllers[0] as? AlertChildPageViewController else { return }
+
         let index = pageContentViewController.pageIndex
         self.currentStep = (arrayOfImage.count - index - 1)
         self.delegate?.nextStep(self.currentStep)

--- a/AlertOnboarding/AlertPageViewController.swift
+++ b/AlertOnboarding/AlertPageViewController.swift
@@ -20,9 +20,9 @@ class AlertPageViewController: UIViewController, UIPageViewControllerDataSource,
     var alertview: AlertOnboarding!
     
     //FOR DATA
-    var arrayOfImage: [String]!
-    var arrayOfTitle: [String]!
-    var arrayOfDescription: [String]!
+    var arrayOfImage: [String]
+    var arrayOfTitle: [String]
+    var arrayOfDescription: [String]
     var viewControllers = [UIViewController]()
     
     //FOR TRACKING USER USAGE
@@ -33,10 +33,11 @@ class AlertPageViewController: UIViewController, UIPageViewControllerDataSource,
     
     
     init (arrayOfImage: [String], arrayOfTitle: [String], arrayOfDescription: [String], alertView: AlertOnboarding) {
-        super.init(nibName: nil, bundle: nil)
         self.arrayOfImage = arrayOfImage
         self.arrayOfTitle = arrayOfTitle
         self.arrayOfDescription = arrayOfDescription
+
+        super.init(nibName: nil, bundle: nil)
         self.alertview = alertView
     }
     

--- a/AlertOnboarding/AlertPageViewController.swift
+++ b/AlertOnboarding/AlertPageViewController.swift
@@ -83,8 +83,11 @@ class AlertPageViewController: UIViewController, UIPageViewControllerDataSource,
     
     
     func pageViewController(_ pageViewController: UIPageViewController, viewControllerAfter viewController: UIViewController) -> UIViewController? {
+        guard let viewController = viewController as? AlertChildPageViewController else {
+            return nil
+        }
         
-        var index = (viewController as! AlertChildPageViewController).pageIndex
+        var index = viewController.pageIndex
         
         if(index == 0){
             return nil
@@ -95,8 +98,11 @@ class AlertPageViewController: UIViewController, UIPageViewControllerDataSource,
     }
     
     func pageViewController(_ pageViewController: UIPageViewController, viewControllerBefore viewController: UIViewController) -> UIViewController? {
+        guard let viewController = viewController as? AlertChildPageViewController else {
+            return nil
+        }
         
-        var index = (viewController as! AlertChildPageViewController).pageIndex
+        var index = viewController.pageIndex
         
         index += 1
         

--- a/AlertOnboarding/AlertPageViewController.swift
+++ b/AlertOnboarding/AlertPageViewController.swift
@@ -199,7 +199,7 @@ class AlertPageViewController: UIViewController, UIPageViewControllerDataSource,
     
     //MARK: Called after notification orientation changement
     func configureConstraintsForPageControl() {
-        let alertViewSizeHeight = UIScreen.main.bounds.height*alertview.percentageRatioHeight
+        let alertViewSizeHeight = UIScreen.main.bounds.height*alertview.heightRatio
         let positionX = alertViewSizeHeight - (alertViewSizeHeight * 0.1) - 50
         self.pageControl.frame = CGRect(x: 0, y: positionX, width: self.view.bounds.width, height: 50)
     }

--- a/AlertOnboarding/AlertPageViewController.swift
+++ b/AlertOnboarding/AlertPageViewController.swift
@@ -150,8 +150,8 @@ class AlertPageViewController: UIViewController, UIPageViewControllerDataSource,
             isCompleted = true
         }
         //Remember the last screen user have seen
-        if currentStep > self.maxStep {
-            self.maxStep = currentStep
+        if currentStep > maxStep {
+            maxStep = currentStep
         }
         
         pageControl.currentPage = arrayOfImage.count - index - 1
@@ -161,7 +161,6 @@ class AlertPageViewController: UIViewController, UIPageViewControllerDataSource,
             alertview.buttonBottom.setTitle(alertview.titleSkipButton, for: UIControl.State())
         }
     }
-    
     
     func presentationCount(for pageViewController: UIPageViewController) -> Int {
         return arrayOfImage.count
@@ -185,7 +184,6 @@ class AlertPageViewController: UIViewController, UIPageViewControllerDataSource,
             let pageControl = UIPageControl.appearance(whenContainedInInstancesOf: [AlertPageViewController.self])
             pageControl.pageIndicatorTintColor = UIColor.clear
             pageControl.currentPageIndicatorTintColor = UIColor.clear
-            
         } else {
             // Fallback on earlier versions
         }
@@ -197,7 +195,7 @@ class AlertPageViewController: UIViewController, UIPageViewControllerDataSource,
         viewControllers = [initialViewController!]
         pageController.setViewControllers(viewControllers, direction: .forward, animated: false, completion: nil)
         
-        self.addChild(pageController)
+        addChild(pageController)
     }
     
     //MARK: Called after notification orientation changement

--- a/AlertOnboarding/AppDelegate.swift
+++ b/AlertOnboarding/AppDelegate.swift
@@ -13,7 +13,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
@@ -41,6 +40,4 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
 
-
 }
-

--- a/AlertOnboarding/AppDelegate.swift
+++ b/AlertOnboarding/AppDelegate.swift
@@ -14,7 +14,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }

--- a/AlertOnboarding/ViewController.swift
+++ b/AlertOnboarding/ViewController.swift
@@ -9,23 +9,23 @@
 import UIKit
 
 class ViewController: UIViewController, AlertOnboardingDelegate {
-    
+
     var alertView: AlertOnboarding!
-    
+
     var arrayOfImage = ["image1", "image2", "image3"]
     var arrayOfTitle = ["CREATE ACCOUNT", "CHOOSE THE PLANET", "DEPARTURE"]
     var arrayOfDescription = ["In your profile, you can view the statistics of its operations and the recommandations of friends",
                               "Purchase tickets on hot tours to your favorite planet and fly to the most comfortable intergalactic spaceships of best companies",
                               "In the process of flight you will be in cryogenic sleep and supply the body with all the necessary things for life"]
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
         alertView = AlertOnboarding(arrayOfImage: arrayOfImage, arrayOfTitle: arrayOfTitle, arrayOfDescription: arrayOfDescription)
         alertView.delegate = self
     }
-    
+
     @IBAction func onTouch(_ sender: AnyObject) {
-        
+
         /*
          
          //IF YOU WANT TO CUSTOM ALERTVIEW
@@ -43,26 +43,25 @@ class ViewController: UIViewController, AlertOnboardingDelegate {
          self.alertView.percentageRatioWidth = 0.5
          
          */
-        
-        
+
         self.alertView.show()
-        
+
     }
-    
-    //--------------------------------------------------------
+
+    // --------------------------------------------------------
     // MARK: DELEGATE METHODS --------------------------------
-    //--------------------------------------------------------
-    
+    // --------------------------------------------------------
+
     func alertOnboardingSkipped(_ currentStep: Int, maxStep: Int) {
         print("Onboarding skipped the \(currentStep) step and the max step he saw was the number \(maxStep)")
     }
-    
+
     func alertOnboardingCompleted() {
         print("Onboarding completed!")
     }
-    
+
     func alertOnboardingNext(_ nextStep: Int) {
         print("Next step triggered! \(nextStep)")
     }
-    
+
 }


### PR DESCRIPTION
When the alertView is dismissed it fades away, then after it fades the background view is removed causing a rather jarring animation as the background suddenly disappears. With this PR the background now fades away along with the alertView for a much smoother transition.